### PR TITLE
Investigate product import vendor assignment bug

### DIFF
--- a/src/lib/client/client.ts
+++ b/src/lib/client/client.ts
@@ -18,12 +18,15 @@ if (typeof window !== "undefined") {
 export const importProductsQuery = async (file: File) => {
   const formData = new FormData()
   formData.append("file", file)
+  
+  // Get fresh token each time this function is called
+  const freshToken = window.localStorage.getItem("medusa_auth_token") || ""
 
   return await fetch(`${backendUrl}/vendor/products/import`, {
     method: "POST",
     body: formData,
     headers: {
-      authorization: `Bearer ${token}`,
+      authorization: `Bearer ${freshToken}`,
       "x-publishable-api-key": publishableApiKey,
     },
   })
@@ -37,12 +40,15 @@ export const uploadFilesQuery = async (files: any[]) => {
   for (const { file } of files) {
     formData.append("files", file)
   }
+  
+  // Get fresh token each time this function is called
+  const freshToken = window.localStorage.getItem("medusa_auth_token") || ""
 
   return await fetch(`${backendUrl}/vendor/uploads`, {
     method: "POST",
     body: formData,
     headers: {
-      authorization: `Bearer ${token}`,
+      authorization: `Bearer ${freshToken}`,
       "x-publishable-api-key": publishableApiKey,
     },
   })


### PR DESCRIPTION
Update product import and file upload queries to fetch a fresh authentication token, resolving incorrect vendor assignment.

The previous implementation initialized the authentication token once at module load. This caused a bug where if a user switched vendor accounts, subsequent product imports or file uploads would still use the stale token from the previously logged-in vendor, leading to products being assigned to the wrong account. Fetching the token dynamically ensures the correct vendor context is always used.

---
<a href="https://cursor.com/background-agent?bcId=bc-4932b843-75de-45fb-a700-d9278d394e97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4932b843-75de-45fb-a700-d9278d394e97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

