### PR TITLE
Investigate product list item limit

### DIFF
--- a/src/routes/products/product-list/components/product-list-table/product-list-table.tsx
+++ b/src/routes/products/product-list/components/product-list-table/product-list-table.tsx
@@ -24,7 +24,7 @@ import { useProductTableQuery } from "../../../../../hooks/table/query/use-produ
 import { useDataTable } from "../../../../../hooks/use-data-table"
 import { productsLoader } from "../../loader"
 
-export const PAGE_SIZE = 5
+export const PAGE_SIZE = 100
 
 export const ProductListTable = () => {
   const { t } = useTranslation()


### PR DESCRIPTION
Increase product list page size to 100 to display all available products, as it was previously hardcoded to 5.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fd3888e-470d-4824-aec3-659bd1f26ffc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4fd3888e-470d-4824-aec3-659bd1f26ffc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

